### PR TITLE
Compatibilidad con NVDA 2026.1

### DIFF
--- a/addon/globalPlugins/NVIDIAMonitor/__init__.py
+++ b/addon/globalPlugins/NVIDIAMonitor/__init__.py
@@ -40,6 +40,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         self.resultados_cache={}
         self.cache_expiracion=1
         self.en_ejecucion=False
+        self.proceso=None
 
     def escribir_log(self,mensaje):
         ruta_log=os.path.join(globalVars.appArgs.configPath, "NVIDIAMonitor.log")

--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description": _("Complemento para obtener información sobre las GPU NVIDIA"),
 	# version
-	"addon_version": "1.0",
+	"addon_version": "1.1",
 	# Author(s)
 	"addon_author": "José Pérez <perezhuancajose@gmail.com> y ayoub <ayoubelbak13@gmail.com>",
 	# URL for the add-on documentation support
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2024.1.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2025.1.0",
+	"addon_lastTestedNVDAVersion": "2026.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Resumen

NVDA 2026.1 es una versión que **rompe la compatibilidad de la API de complementos**, por lo que NVDA bloquea automáticamente cualquier addon cuya `lastTestedNVDAVersion` sea anterior. Esto hacía que NVIDIA Monitor apareciera como incompatible en NVDA 2026.1.x y dejara de cargar.

He comprobado que el complemento **no utiliza ninguna API eliminada o deprecada** en 2026.1 (`versionInfo.version_*`, `md2html`, `synthDrivers.sapi4`), así que basta con actualizar la versión probada en el manifiesto. No hay cambios de comportamiento.

## Cambios

- **buildVars.py**: `lastTestedNVDAVersion` `2025.1.0` → `2026.1.0`
- **buildVars.py**: versión `1.0` → `1.1`
- **__init__.py**: inicializar `self.proceso = None` en `__init__`. Corrige un `AttributeError` latente en `terminate()` cuando NVDA se cierra sin que el complemento se haya usado nunca (antes `self.proceso` solo se definía dentro de `ejecutar_script`).

## Pruebas

Probado en NVDA 2026.1.1 (2026.1.1.55980): el complemento instala, carga sin advertencia de incompatibilidad y todos los atajos responden con normalidad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)